### PR TITLE
Fix bug with RegExp route paths

### DIFF
--- a/getHAL.js
+++ b/getHAL.js
@@ -18,18 +18,21 @@ module.exports = (server, options) => (url) => {
       // path as it was defined by the developer in server.get(<path>)
       var path = route.spec.path;
 
-      // route might contain parameters
-      // check piece by piece to deal with url parameters
-      var pathPieces = cleanRoutePieces(path.split("/"));
+        // Avoid trying to match paths that are RegExps
+      if (!(path instanceof RegExp)) {
+          // route might contain parameters
+          // check piece by piece to deal with url parameters
+          var pathPieces = cleanRoutePieces(path.split("/"));
 
-      // check if this path should be added to the HAL response of this request
-      if ( urlMatches(pathPieces, urlPieces) ) {
-        matches.push({
-          pathPieces: pathPieces,
-          route: route,
-          method: method
-        });
+          // check if this path should be added to the HAL response of this request
+          if ( urlMatches(pathPieces, urlPieces) ) {
+              matches.push({
+                  pathPieces: pathPieces,
+                  route: route,
+                  method: method
+              });
 
+          }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-json-hal",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "extends restify with JSON HAL",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When the library attempted to parse a route with a path defined as a
RegExp, it would return an error when attempting to split the
path. Adding a check for the type of the path variable fixes this bug.