### PR TITLE
Fix undefined options bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 var halCache = {};
 
 module.exports = (server, options) => {
-  var getHAL = require('./getHAL.js')(server, options);
   options = options || {};
   options.prefix = options.prefix || "";
   options.makeObjects = options.makeObjects || false;
 
+  var getHAL = require('./getHAL.js')(server, options);
   var addLink = require('./addLink.js')(server, options);
 
   // override json formatter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-json-hal",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "extends restify with JSON HAL",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When the user does not pass options in at instantiation, an error is
caused by passing the `undefined` options variable into
`getHAL.js`. Moving the `require()` of `getHAL` to after the `options`
object is checked fixes the bug.

*Note*: This pull request must be merged after the previous pull request, #1, because it increments the version number to `0.1.3` and the previous one increments it to `0.1.2`.